### PR TITLE
Fixed the regex in MainVisibilityNauticalMilesCommand

### DIFF
--- a/metar_taf_parser/command/common.py
+++ b/metar_taf_parser/command/common.py
@@ -185,7 +185,7 @@ class MinimalVisibilityCommand:
 
 class MainVisibilityNauticalMilesCommand:
 
-    regex = r'^(\d)*(\s)?((\d\/\d)?SM)$'
+    regex = r'^(P|M)?(\d)*(\s)?((\d\/\d)?SM)$'
 
     def __init__(self):
         self._pattern = re.compile(MainVisibilityNauticalMilesCommand.regex)

--- a/metar_taf_parser/tests/command/test_common.py
+++ b/metar_taf_parser/tests/command/test_common.py
@@ -1,6 +1,6 @@
 import unittest
 
-from metar_taf_parser.command.common import CloudCommand, WindCommand, CommandSupplier
+from metar_taf_parser.command.common import CloudCommand, MainVisibilityNauticalMilesCommand, WindCommand, CommandSupplier
 from metar_taf_parser.model.enum import CloudQuantity, CloudType
 from metar_taf_parser.model.model import Metar
 
@@ -79,6 +79,14 @@ class CommonTestCase(unittest.TestCase):
         command = WindCommand()
         metar = Metar()
         self.assertTrue(command.execute(metar, 'VRB08KT'))
+
+    def test_main_visibility_nautical_miles_command_with_greater_than(self):
+        command = MainVisibilityNauticalMilesCommand()
+        self.assertTrue(command.can_parse('P3SM'))
+
+    def test_main_visibility_nautical_miles_command_with_minus_than(self):
+        command = MainVisibilityNauticalMilesCommand()
+        self.assertTrue(command.can_parse('M1SM'))
 
 
 if __name__ == '__main__':

--- a/metar_taf_parser/tests/parser/test_parser.py
+++ b/metar_taf_parser/tests/parser/test_parser.py
@@ -664,6 +664,25 @@ class TAFParserTestCase(unittest.TestCase):
         self.assertEqual(1, len(taf.tempos()[0].weather_conditions[0].phenomenons))
         self.assertEqual(Phenomenon.SNOW, taf.tempos()[0].weather_conditions[0].phenomenons[0])
 
+    def test_parse_trend_visibility(self):
+        taf = TAFParser().parse(
+            """TAF AMD KEWR 191303Z 1913/2018 09006KT 5SM -RA BR BKN007 OVC025
+            FM191600 17007KT P6SM BKN020
+            FM192100 26008KT P3SM SCT030 SCT050
+            FM200000 29005KT P4SM SCT050
+            FM200600 VRB03KT P9SM SCT050
+            """
+        )
+
+        self.assertEqual('KEWR', taf.station)
+        self.assertIsNotNone(taf.visibility)
+        self.assertEqual('5SM', taf.visibility.distance)
+        self.assertEqual(4, len(taf.fms()))
+        self.assertEqual('P6SM', taf.fms()[0].visibility.distance)
+        self.assertEqual('P3SM', taf.fms()[1].visibility.distance)
+        self.assertEqual('P4SM', taf.fms()[2].visibility.distance)
+        self.assertEqual('P9SM', taf.fms()[3].visibility.distance)
+
 
 class RemarkParserTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Fixed the regex to include `P` or `M` when visibility is in miles.

This fixes #23 