### PR TITLE
feat: removed keyword 'METAR' before entering tokenizer

### DIFF
--- a/metar_taf_parser/parser/parser.py
+++ b/metar_taf_parser/parser/parser.py
@@ -144,7 +144,7 @@ class AbstractParser(abc.ABC):
         :param input: The metar or TAF as string
         :return: List of tokens
         """
-        return list(filter(None, self._tokenize_regex_pattern.split(input)))
+        return list(filter(None, self._tokenize_regex_pattern.split(input.replace('METAR',''))))
 
     def general_parse(self, abstract_weather_container: AbstractWeatherContainer, input: str):
         """

--- a/metar_taf_parser/parser/parser.py
+++ b/metar_taf_parser/parser/parser.py
@@ -144,7 +144,7 @@ class AbstractParser(abc.ABC):
         :param input: The metar or TAF as string
         :return: List of tokens
         """
-        return list(filter(None, self._tokenize_regex_pattern.split(input.replace('METAR',''))))
+        return list(filter(None, self._tokenize_regex_pattern.split(input.replace('METAR', ''))))
 
     def general_parse(self, abstract_weather_container: AbstractWeatherContainer, input: str):
         """


### PR DESCRIPTION
Some METAR services provider (like Argentina's [national weather service](https://www.smn.gob.ar/metar)) add the message keyword in the report and it breaks the parser. My small modification cleans "METAR" keyword before sending it to the tokenize function.

Example message that would break the parser function:
`METAR SAEZ 302100Z 08007KT CAVOK 30/14 Q1007 NOSIG RMK PP000 =`

TAF keyword not removed because it's required in `TAFParser`.

Amazing work!