### PR TITLE
Update regex in MinimalVisibilityCommand and WindCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log 
 
+## [1.6.3] - 2023-03-12
+
+### Fixed
+
+- Parsing of token `0000KT` no longer causes an error.
+
 ## [1.6.2] - 2023-01-29
 
 ### Fixed

--- a/metar_taf_parser/command/common.py
+++ b/metar_taf_parser/command/common.py
@@ -79,7 +79,7 @@ class MainVisibilityCommand:
 
 
 class WindCommand:
-    regex = r'^(VRB|[0-3]\d{2})(\d{2})G?(\d{2})?(KT|MPS|KM\/H)?'
+    regex = r'^(VRB|00|[0-3]\d{2})(\d{2})G?(\d{2})?(KT|MPS|KM\/H)?'
 
     def __init__(self):
         self._pattern = re.compile(WindCommand.regex)
@@ -163,7 +163,7 @@ class VerticalVisibilityCommand:
 
 
 class MinimalVisibilityCommand:
-    regex = r'^(\d{4}[a-z])$'
+    regex = r'^(\d{4}[NnEeSsWw])$'
 
     def __init__(self):
         self._pattern = re.compile(MinimalVisibilityCommand.regex)

--- a/metar_taf_parser/tests/parser/test_parser.py
+++ b/metar_taf_parser/tests/parser/test_parser.py
@@ -288,6 +288,15 @@ class MetarParserTestCase(unittest.TestCase):
         self.assertEqual('03 mm', metar.runways_info[0].thickness)
         self.assertEqual(_('DepositBrakingCapacity.default').format(0.35), metar.runways_info[0].braking_capacity)
 
+    def test_parse_empty_wind(self):
+
+        metar = MetarParser().parse('KATW 022045Z 0000KT 10SM SCT120 00/M08 A2996')
+
+        self.assertEqual('KATW', metar.station)
+        self.assertIsNotNone(metar.wind)
+        self.assertEqual(0, metar.wind.speed)
+        self.assertEqual(0, metar.wind._degrees)
+
 
 class FunctionTestCase(unittest.TestCase):
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = metar-taf-parser-mivek
-version = 1.6.2
+version = 1.6.3
 author = Jean-Kevin KPADEY
 author_email = jeankevin.kpadey@gmail.com
 description = Python project parsing metar and taf message


### PR DESCRIPTION
Empty wind token 0000KT was parsed as a MiminalVisibility instead of a Wind.