### PR TITLE
Fix TAF with stations starting with FM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log 
 
+## [1.6.4] - 2023-06-TBD
+
+### Fixed
+
+- Parsing of `TAF` with stations starting by `FM`.
+
 ## [1.6.3] - 2023-03-12
 
 ### Fixed

--- a/metar_taf_parser/parser/parser.py
+++ b/metar_taf_parser/parser/parser.py
@@ -299,7 +299,7 @@ class TAFParser(AbstractParser):
         """
         single_line = taf_code.replace('\n', ' ')
         clean_line = re.sub(r'\s{2,}', ' ', single_line)
-        lines = re.sub(r'\s(PROB\d{2}\sTEMPO|TEMPO|INTER|BECMG|FM|PROB)', '\n\g<1>', clean_line).splitlines()
+        lines = re.sub(r'\s(PROB\d{2}\sTEMPO|TEMPO|INTER|BECMG|FM(?![A-Z]{2}\s)|PROB)', '\n\g<1>', clean_line).splitlines()
         lines_token = [self.tokenize(line) for line in lines]
 
         if len(lines_token) > 1:

--- a/metar_taf_parser/tests/parser/test_parser.py
+++ b/metar_taf_parser/tests/parser/test_parser.py
@@ -801,6 +801,22 @@ class TAFParserTestCase(unittest.TestCase):
         self.assertEqual(1, len(taf.becmgs()[5].icings))
         self.assertEqual(2, len(taf.becmgs()[5].turbulence))
 
+    def test_parse_with_station_begining_with_FM(self):
+        taf = TAFParser().parse(
+            """TAF FMMI 082300Z 0900/1006 16006KT 9999 FEW017 BKN020 PROB30
+            TEMPO 0908/0916 4500 RADZ
+            BECMG 0909/0911 10010KT
+            BECMG 0918/0920 16006KT
+            """
+        )
+
+        self.assertIsNotNone(taf)
+        self.assertEqual('FMMI', taf.station)
+
+        self.assertEqual(8, taf.day)
+        self.assertEqual(23, taf.time.hour)
+        self.assertEqual(0, taf.time.minute)
+
 
 class RemarkParserTestCase(unittest.TestCase):
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = metar-taf-parser-mivek
-version = 1.6.3
+version = 1.6.4
 author = Jean-Kevin KPADEY
 author_email = jeankevin.kpadey@gmail.com
 description = Python project parsing metar and taf message


### PR DESCRIPTION
Fix the parsing of station starting with FM in TAF

The `FM` part of the station was recognized as a FMTrend.