### PR TITLE
getdefaultlocale() may return (None, "UTF-8")

### DIFF
--- a/metar_taf_parser/commons/i18n.py
+++ b/metar_taf_parser/commons/i18n.py
@@ -7,7 +7,10 @@ from metar_taf_parser.commons.exception import TranslationError
 
 localedir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../locale')
 langAvailable = os.listdir(localedir)
-lang = locale.getdefaultlocale()[0][:2]
+loc = locale.getdefaultlocale()
+lang = 'en'
+if loc is not None and loc[0] is not None and len(loc[0]) >= 2:
+    lang = loc[0][:2]
 if lang not in langAvailable:
     lang = 'en'
 t = gettext.translation(domain='messages', localedir=localedir, fallback=True, languages=[lang])


### PR DESCRIPTION
When running in env. like ipython or inside editors/debuggers, `locale.getdefaultlocale()` may return (None, "UTF-8").