### PR TITLE
Supports 3 digits in gusts for Wind and WindShear elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log 
 
+## [1.7.0] - 2023-08-20
+
+### Added
+
+- `Wind` and `WindShear` elements now supports 3 digits in gusts part
+
 ## [1.6.5] - 2023-08-06
 
 ### Added

--- a/metar_taf_parser/command/common.py
+++ b/metar_taf_parser/command/common.py
@@ -79,7 +79,7 @@ class MainVisibilityCommand:
 
 
 class WindCommand:
-    regex = r'^(VRB|00|[0-3]\d{2})(\d{2})G?(\d{2})?(KT|MPS|KM\/H)?'
+    regex = r'^(VRB|00|[0-3]\d{2})(\d{2})G?(\d{2,3})?(KT|MPS|KM\/H)?'
 
     def __init__(self):
         self._pattern = re.compile(WindCommand.regex)
@@ -125,7 +125,7 @@ class WindVariationCommand:
 
 
 class WindShearCommand:
-    regex = r'^WS(\d{3})\/(\w{3})(\d{2})G?(\d{2})?(KT|MPS|KM\/H)'
+    regex = r'^WS(\d{3})\/(\w{3})(\d{2})G?(\d{2,3})?(KT|MPS|KM\/H)'
 
     def __init__(self):
         self._pattern = re.compile(WindShearCommand.regex)

--- a/metar_taf_parser/tests/command/test_common.py
+++ b/metar_taf_parser/tests/command/test_common.py
@@ -61,6 +61,16 @@ class CommonTestCase(unittest.TestCase):
         self.assertEqual(20, wind.gust)
         self.assertEqual('KT', wind.unit)
 
+    def test_wind_command_parse_gusts_3_digits(self):
+        command = WindCommand()
+
+        wind = command.parse_wind('12017G015KT')
+        self.assertEqual('ESE', wind.direction)
+        self.assertEqual(120, wind.degrees)
+        self.assertEqual(17, wind.speed)
+        self.assertEqual(15, wind.gust)
+        self.assertEqual('KT', wind.unit)
+
     def test_parse_wind_command_parse_wind_variable(self):
         command = WindCommand()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = metar-taf-parser-mivek
-version = 1.6.5
+version = 1.7.0
 author = Jean-Kevin KPADEY
 author_email = jeankevin.kpadey@gmail.com
 description = Python project parsing metar and taf message


### PR DESCRIPTION
This is a backport of  https://github.com/mivek/MetarParser/pull/514