### PR TITLE
fix: resolve SonarCloud issues

### DIFF
--- a/metar_taf_parser/commons/i18n.py
+++ b/metar_taf_parser/commons/i18n.py
@@ -4,6 +4,7 @@ import locale
 import os
 import threading
 from contextlib import contextmanager
+from typing import Optional
 
 from metar_taf_parser.commons.exception import TranslationError
 
@@ -24,7 +25,7 @@ for _loc_name in SUPPORTED_LOCALES:
         _PREFIX_MAP[_prefix] = _loc_name
 
 
-def _resolve(loc: str) -> str:
+def _resolve(loc: Optional[str]) -> str:
     """Normalize a user-supplied locale string to an actual SUPPORTED_LOCALES dir name."""
     if not loc:
         return DEFAULT_LOCALE

--- a/metar_taf_parser/model/model.py
+++ b/metar_taf_parser/model/model.py
@@ -1,5 +1,6 @@
 import abc
 import datetime
+from typing import Optional
 
 from metar_taf_parser.model.enum import Descriptive, Flag, WeatherChangeType, TimeIndicator, IcingIntensity, TurbulenceIntensity
 
@@ -386,7 +387,7 @@ class AbstractWeatherLayer(abc.ABC):
 class Icing(AbstractWeatherLayer):
     def __init__(self):
         super().__init__()
-        self._intensity: IcingIntensity = None
+        self._intensity: Optional[IcingIntensity] = None
 
     def _get_intensity(self):
         return self._intensity
@@ -404,7 +405,7 @@ class Turbulence(AbstractWeatherLayer):
 
     def __init__(self):
         super().__init__()
-        self._intensity: TurbulenceIntensity = None
+        self._intensity: Optional[TurbulenceIntensity] = None
 
     def _get_intensity(self):
         return self._intensity

--- a/metar_taf_parser/parser/parser.py
+++ b/metar_taf_parser/parser/parser.py
@@ -121,32 +121,32 @@ class AbstractParser(abc.ABC):
     def parse(self, input: str):
         pass
 
-    def _parse_weather_condition(self, input: str):
+    def _parse_weather_condition(self, weather_str: str):
         """
         Parses a string into a weather condition. The result is not necessarily valid
-        :param input: The input to parse
+        :param weather_str: The input to parse
         :return: WeatherCondition object
         """
         weather_condition = WeatherCondition()
-        if self._intensity_regex_pattern.match(input):
-            match = self._intensity_regex_pattern.findall(input)[0]
+        if self._intensity_regex_pattern.match(weather_str):
+            match = self._intensity_regex_pattern.findall(weather_str)[0]
             weather_condition.intensity = Intensity(match)
-            input = input[len(match):]
+            weather_str = weather_str[len(match):]
 
         for name, member in Descriptive.__members__.items():
-            if member.value in input:
+            if member.value in weather_str:
                 weather_condition.descriptive = member
-                input = input[len(member.value):]
+                weather_str = weather_str[len(member.value):]
 
         previous_token = ''
-        while input != '' and input != previous_token:
-            previous_token = input
+        while weather_str != '' and weather_str != previous_token:
+            previous_token = weather_str
             for name, member in Phenomenon.__members__.items():
-                if re.match(r'^' + member.value, input):
+                if re.match(r'^' + member.value, weather_str):
                     weather_condition.add_phenomenon(member)
-                    input = input[len(member.value):]
+                    weather_str = weather_str[len(member.value):]
 
-        return weather_condition if input == '' and weather_condition.is_valid() else None
+        return weather_condition if weather_str == '' and weather_condition.is_valid() else None
 
     def tokenize(self, input: str):
         """

--- a/metar_taf_parser/tests/commons/test_i18n.py
+++ b/metar_taf_parser/tests/commons/test_i18n.py
@@ -89,7 +89,7 @@ class TestTranslationLocaleContextManager(unittest.TestCase):
     def test_locale_restored_after_block(self):
         locale_before = get_locale()
         with translation_locale('de'):
-            pass
+            self.assertEqual(get_locale(), 'de')
         self.assertEqual(get_locale(), locale_before)
 
     def test_none_is_noop(self):

--- a/metar_taf_parser/tests/parser/test_parser.py
+++ b/metar_taf_parser/tests/parser/test_parser.py
@@ -72,9 +72,9 @@ class AbstractParserTestCase(unittest.TestCase):
 class MetarParserTestCase(unittest.TestCase):
 
     def test_parse(self):
-        input = 'LFPG 170830Z 00000KT 0350 R27L/0375N R09R/0175N R26R/0500D R08L/0400N R26L/0275D R08R/0250N R27R/0300N R09L/0200N FG SCT000 M01/M01 Q1026 NOSIG'
+        metar_str = 'LFPG 170830Z 00000KT 0350 R27L/0375N R09R/0175N R26R/0500D R08L/0400N R26L/0275D R08R/0250N R27R/0300N R09L/0200N FG SCT000 M01/M01 Q1026 NOSIG'
 
-        metar = MetarParser().parse(input)
+        metar = MetarParser().parse(metar_str)
 
         self.assertEqual('LFPG', metar.station)
         self.assertEqual(17, metar.day)
@@ -389,7 +389,7 @@ class TAFParserTestCase(unittest.TestCase):
 
         self.assertEqual(170, taf.wind.degrees)
         self.assertEqual(5, taf.wind.speed)
-        self.assertEqual(None, taf.wind.gust)
+        self.assertIsNone(taf.wind.gust)
         self.assertEqual('KT', taf.wind.unit)
 
         self.assertEqual('6000', taf.visibility.distance)


### PR DESCRIPTION
- fix(i18n): update _resolve() signature to Optional[str] (S5655)
- fix(model): use Optional[IcingIntensity/TurbulenceIntensity] type hints (S5890)
- fix(parser): rename 'input' param to 'weather_str' in _parse_weather_condition (S5806)
- fix(tests): rename 'input' variable in test_parser to avoid shadowing builtin (S5806)
- fix(tests): replace assertEqual(None, ...) with assertIsNone (S5906)
- fix(tests): fill empty with-block in test_i18n with locale assertion (S108)